### PR TITLE
Fix Rubymine 7.0 RC build

### DIFF
--- a/rubymine-eap/PKGBUILD
+++ b/rubymine-eap/PKGBUILD
@@ -6,7 +6,7 @@
 pkgname='rubymine-eap'
 _pkgname='RubyMine'
 _pkgver='139.160'
-pkgver="7.0_${_pkgver}"
+pkgver="7.0"
 pkgrel='1'
 pkgdesc="Ruby and Rails IDE with the full stack of essential developer tools (Tsubaki EAP)"
 arch=('i686' 'x86_64')
@@ -25,7 +25,7 @@ PKGEXT='.pkg.tar.gz' # prevent a time-consuming compression with xz
 package() {
   cd "${srcdir}"
 
-  realsrcdir="${_pkgname}-${_pkgver}/"
+  realsrcdir="${_pkgname}-${pkgver}/"
 
   mkdir -p "${pkgdir}/opt/${pkgname}"
   cp -r ${srcdir}/${realsrcdir}* "${pkgdir}/opt/${pkgname}"


### PR DESCRIPTION
This make the script match new names :
The package file is called 'RubyMine-139.160.tar.gz', but the inner folder is called 'RubyMine-7.0'
