### PR TITLE
PKGBUILD needs a package step.

### DIFF
--- a/teamcity-agent/PKGBUILD
+++ b/teamcity-agent/PKGBUILD
@@ -21,7 +21,7 @@ md5sums=('cf1268c622908047db1cc0f5987ad4ca'
 _AGENT_URL='YOURHOST/update/buildAgent.zip'
 
 
-build() {
+package() {
   if [ -z "${_AGENT_URL}" ] || [ "${_AGENT_URL}" == 'YOURHOST/update/buildAgent.zip' ]; then
     echo 'Please edit PKGBUILD before installing.'
     exit 1

--- a/teamcity/PKGBUILD
+++ b/teamcity/PKGBUILD
@@ -21,7 +21,7 @@ sha512sums=('2ae69d942bf29f0b03d33766a2ad7bb7eb614641148ba42540e3eab45e5906291e9
 options=('!strip')
 PKGEXT='.pkg.tar'
 
-build() {
+package() {
   mkdir -p "${pkgdir}/usr/share/licenses"
   mkdir -p "${pkgdir}/var/lib/teamcity"
   mkdir -p "${pkgdir}/opt/${pkgname}"


### PR DESCRIPTION
PKGBUILD are required to have a package function now. We should use that instead of build.